### PR TITLE
refactors; improved errors; accept `--` arbitrary positionals

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 const HELP_TEXT: &str = "\
-Usage: jsonkdl [options] [--] <input> <output>
+Usage: jsonkdl [options] [--] <input> [<output>]
 Converts JSON to KDL.
 By default, KDL spec v2 is used.
 
@@ -18,7 +18,9 @@ Options:
 
 Arguments:
   <input>          Path to input JSON file
-  <output>         Path to output KDL file
+  <output>         Path to output KDL file (optional)
+
+If no output file is provided, the resulting KDL document is printed to standard output.
 ";
 
 #[derive(Debug)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,7 @@ pub enum CliError {
     MissingInput,
     HelpRequested,
     MultipleKdlVersion,
+    UnknownOption(String),
     InvalidInputPath(String),
     FileExists(String),
     InputNotFound(String),
@@ -48,6 +49,7 @@ impl std::fmt::Display for CliError {
             CliError::MissingInput => writeln!(f, "missing input path"),
             CliError::HelpRequested => writeln!(f, "help requested"),
             CliError::MultipleKdlVersion => writeln!(f, "specify only one of --kdl-v1 or --kdl-v2"),
+            CliError::UnknownOption(opt) => writeln!(f, "unknown command-line option {opt}"),
             CliError::InvalidInputPath(path) => writeln!(f, "not a file: {}", path),
             CliError::FileExists(path) => {
                 writeln!(f, "file exists: {} (use --force to overwrite)", path)
@@ -102,6 +104,8 @@ impl Args {
                 }
             } else if arg == "-h" || arg == "--help" {
                 return Err(CliError::HelpRequested);
+            } else {
+                return Err(CliError::UnknownOption(arg.into()));
             }
         }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,11 +7,10 @@ use std::path::{Path, PathBuf};
 const HELP_TEXT: &str = "\
 Usage: jsonkdl [options] [--] <input> [<output>]
 Converts JSON to KDL.
-By default, KDL spec v2 is used.
 
 Options:
   -1, --kdl-v1     Convert to KDL v1
-  -2, --kdl-v2     Convert to KDL v2
+  -2, --kdl-v2     Convert to KDL v2 (default)
   -f, --force      Overwrite output if it exists
   -v, --verbose    Print extra information during conversion
   -h, --help       Show this help message

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::convert::ConversionError;
+use crate::convert::{ConversionError, KdlVersion};
 use crate::convert::{convert_and_write_file_content, convert_file_content};
 use std::env;
 use std::path::Path;
@@ -39,7 +39,7 @@ pub struct Args {
     pub output: Option<String>,
     pub force: bool,
     pub verbose: bool,
-    pub kdl_version: i32,
+    pub kdl_version: KdlVersion,
 }
 
 impl std::fmt::Display for CliError {
@@ -79,7 +79,7 @@ impl Args {
         let mut positional: Vec<String> = vec![];
         let mut force = false;
         let mut verbose = false;
-        let mut kdl_version = 0;
+        let mut kdl_version = None;
 
         if args.len() == 1 {
             return Err(CliError::HelpRequested);
@@ -93,25 +93,19 @@ impl Args {
             } else if arg == "-v" || arg == "--verbose" {
                 verbose = true;
             } else if arg == "-1" || arg == "--kdl-v1" {
-                if kdl_version != 0 {
+                if kdl_version.replace(KdlVersion::V1).is_some() {
                     return Err(CliError::MultipleKdlVersion);
                 }
-
-                kdl_version = 1;
             } else if arg == "-2" || arg == "--kdl-v2" {
-                if kdl_version != 0 {
+                if kdl_version.replace(KdlVersion::V2).is_some() {
                     return Err(CliError::MultipleKdlVersion);
                 }
-
-                kdl_version = 2;
             } else if arg == "-h" || arg == "--help" {
                 return Err(CliError::HelpRequested);
             }
         }
 
-        if kdl_version == 0 {
-            kdl_version = 2;
-        };
+        let kdl_version = kdl_version.unwrap_or_default();
 
         let input = positional.get(0).ok_or(CliError::MissingInput)?.to_string();
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,6 +26,7 @@ pub enum CliError {
     HelpRequested,
     MultipleKdlVersion,
     UnknownOption(String),
+    TooManyPositionals,
     InvalidInputPath(String),
     FileExists(String),
     InputNotFound(String),
@@ -50,6 +51,7 @@ impl std::fmt::Display for CliError {
             CliError::HelpRequested => writeln!(f, "help requested"),
             CliError::MultipleKdlVersion => writeln!(f, "specify only one of --kdl-v1 or --kdl-v2"),
             CliError::UnknownOption(opt) => writeln!(f, "unknown command-line option {opt}"),
+            CliError::TooManyPositionals => writeln!(f, "too many positional arguments"),
             CliError::InvalidInputPath(path) => writeln!(f, "not a file: {}", path),
             CliError::FileExists(path) => {
                 writeln!(f, "file exists: {} (use --force to overwrite)", path)
@@ -114,6 +116,10 @@ impl Args {
         let input = positional.get(0).ok_or(CliError::MissingInput)?.to_string();
 
         let output = positional.get(1).map(|s| s.to_string());
+
+        if positional.len() > 2 {
+            return Err(CliError::TooManyPositionals);
+        }
 
         let result = Self {
             input,

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -100,6 +100,10 @@ pub fn convert_document(json: &JsonValue) -> Result<KdlDocument> {
 }
 
 fn convert_node(json: &JsonValue) -> Result<KdlNode> {
+    let json = json
+        .as_object()
+        .ok_or_else(|| ConversionError::InvalidStructure("node must be an object".to_string()))?;
+
     let name = json
         .get("name")
         .and_then(|n| n.as_str())

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -160,7 +160,18 @@ fn convert_entry(json: &JsonValue) -> Result<KdlEntry> {
         (json, None)
     };
 
-    let kdl_value = match actual_value {
+    let kdl_value = convert_value(actual_value)?;
+
+    let mut entry = KdlEntry::new(kdl_value);
+    if let Some(ty) = type_annotation {
+        entry.set_ty(ty);
+    }
+
+    Ok(entry)
+}
+
+fn convert_value(json: &JsonValue) -> Result<KdlValue> {
+    Ok(match json {
         JsonValue::Null => KdlValue::Null,
         JsonValue::Bool(b) => KdlValue::Bool(*b),
         JsonValue::Number(n) => {
@@ -180,12 +191,5 @@ fn convert_entry(json: &JsonValue) -> Result<KdlEntry> {
                 "unsupported json value type for kdl conversion".to_string(),
             ));
         }
-    };
-
-    let mut entry = KdlEntry::new(kdl_value);
-    if let Some(ty) = type_annotation {
-        entry.set_ty(ty);
-    }
-
-    Ok(entry)
+    })
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,4 +1,4 @@
-use kdl::{KdlDocument, KdlEntry, KdlIdentifier, KdlNode, KdlValue, NodeKey};
+use kdl::{KdlDocument, KdlEntry, KdlIdentifier, KdlNode, KdlValue};
 use serde_json::Value as JsonValue;
 use std::{fmt, fs, path::Path};
 
@@ -125,8 +125,9 @@ fn convert_node(json: &JsonValue) -> Result<KdlNode> {
         })?;
 
         for (key, prop_value) in properties {
-            let entry = convert_entry(prop_value)?;
-            node.insert(NodeKey::from(key.clone()), entry);
+            let mut entry = convert_entry(prop_value)?;
+            entry.set_name(Some(key.as_str()));
+            node.push(entry);
         }
     }
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -53,7 +53,7 @@ pub enum KdlVersion {
 pub fn convert_file_content(input: &Path, version: KdlVersion) -> Result<String> {
     let json_content = fs::read_to_string(input)?;
     let json_value: JsonValue = serde_json::from_str(&json_content)?;
-    let mut kdl_doc = convert_document(json_value)?;
+    let mut kdl_doc = convert_document(&json_value)?;
 
     // For some reason, you MUST autoformat before ensuring version.
     kdl_doc.autoformat();
@@ -83,7 +83,7 @@ pub fn convert_and_write_file_content(
     Ok(())
 }
 
-pub fn convert_document(json: JsonValue) -> Result<KdlDocument> {
+pub fn convert_document(json: &JsonValue) -> Result<KdlDocument> {
     let array = json.as_array().ok_or_else(|| {
         ConversionError::InvalidStructure("document root must be json array".to_string())
     })?;
@@ -131,7 +131,7 @@ fn convert_node(json: &JsonValue) -> Result<KdlNode> {
 
     // Handle children
     if let Some(children) = json.get("children") {
-        let child_doc = convert_document(children.clone())?;
+        let child_doc = convert_document(children)?;
         node.set_children(child_doc);
     }
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -171,25 +171,23 @@ fn convert_entry(json: &JsonValue) -> Result<KdlEntry> {
 }
 
 fn convert_value(json: &JsonValue) -> Result<KdlValue> {
-    Ok(match json {
-        JsonValue::Null => KdlValue::Null,
-        JsonValue::Bool(b) => KdlValue::Bool(*b),
+    match json {
+        JsonValue::Null => Ok(KdlValue::Null),
+        JsonValue::Bool(b) => Ok(KdlValue::Bool(*b)),
         JsonValue::Number(n) => {
             if let Some(i) = n.as_i64() {
-                KdlValue::Integer(i as i128)
+                Ok(KdlValue::Integer(i as i128))
             } else if let Some(f) = n.as_f64() {
-                KdlValue::Float(f)
+                Ok(KdlValue::Float(f))
             } else {
-                return Err(ConversionError::InvalidStructure(
+                Err(ConversionError::InvalidStructure(
                     "invalid number value".to_string(),
-                ));
+                ))
             }
         }
-        JsonValue::String(s) => KdlValue::String(s.clone()),
-        _ => {
-            return Err(ConversionError::InvalidStructure(
-                "unsupported json value type for kdl conversion".to_string(),
-            ));
-        }
-    })
+        JsonValue::String(s) => Ok(KdlValue::String(s.clone())),
+        _ => Err(ConversionError::InvalidStructure(
+            "unsupported json value type for kdl conversion".to_string(),
+        )),
+    }
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -53,17 +53,18 @@ pub enum KdlVersion {
 pub fn convert_file_content(input: &Path, version: KdlVersion) -> Result<String> {
     let json_content = fs::read_to_string(input)?;
     let json_value: JsonValue = serde_json::from_str(&json_content)?;
-    let mut kdl_doc = convert_document(&json_value)?;
+
+    let mut document = convert_document(&json_value)?;
 
     // For some reason, you MUST autoformat before ensuring version.
-    kdl_doc.autoformat();
+    document.autoformat();
 
     match version {
-        KdlVersion::V1 => kdl_doc.ensure_v1(),
-        KdlVersion::V2 => kdl_doc.ensure_v2(),
+        KdlVersion::V1 => document.ensure_v1(),
+        KdlVersion::V2 => document.ensure_v2(),
     }
 
-    Ok(kdl_doc.to_string())
+    Ok(document.to_string())
 }
 
 pub fn convert_and_write_file_content(

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -53,7 +53,7 @@ pub enum KdlVersion {
 pub fn convert_file_content(input: &Path, version: KdlVersion) -> Result<String> {
     let json_content = fs::read_to_string(input)?;
     let json_value: JsonValue = serde_json::from_str(&json_content)?;
-    let mut kdl_doc = json_to_kdl(json_value)?;
+    let mut kdl_doc = convert_document(json_value)?;
 
     // For some reason, you MUST autoformat before ensuring version.
     kdl_doc.autoformat();
@@ -83,7 +83,7 @@ pub fn convert_and_write_file_content(
     Ok(())
 }
 
-pub fn json_to_kdl(json: JsonValue) -> Result<KdlDocument> {
+pub fn convert_document(json: JsonValue) -> Result<KdlDocument> {
     let array = json.as_array().ok_or_else(|| {
         ConversionError::InvalidStructure("document root must be json array".to_string())
     })?;
@@ -91,14 +91,14 @@ pub fn json_to_kdl(json: JsonValue) -> Result<KdlDocument> {
     let mut document = KdlDocument::new();
 
     for value in array {
-        let node = json_value_to_node(value)?;
+        let node = convert_node(value)?;
         document.nodes_mut().push(node);
     }
 
     Ok(document)
 }
 
-fn json_value_to_node(json: &JsonValue) -> Result<KdlNode> {
+fn convert_node(json: &JsonValue) -> Result<KdlNode> {
     let name = json.get("name").and_then(|n| n.as_str()).ok_or_else(|| {
         ConversionError::InvalidStructure("name must be non-empty string".to_string())
     })?;
@@ -112,7 +112,7 @@ fn json_value_to_node(json: &JsonValue) -> Result<KdlNode> {
         })?;
 
         for arg in args {
-            let entry = json_value_to_entry(arg)?;
+            let entry = convert_entry(arg)?;
             node.push(entry);
         }
     }
@@ -124,14 +124,14 @@ fn json_value_to_node(json: &JsonValue) -> Result<KdlNode> {
         })?;
 
         for (key, prop_value) in props {
-            let entry = json_value_to_entry(prop_value)?;
+            let entry = convert_entry(prop_value)?;
             node.insert(NodeKey::from(key.clone()), entry);
         }
     }
 
     // Handle children
     if let Some(children) = json.get("children") {
-        let child_doc = json_to_kdl(children.clone())?;
+        let child_doc = convert_document(children.clone())?;
         node.set_children(child_doc);
     }
 
@@ -147,7 +147,7 @@ fn json_value_to_node(json: &JsonValue) -> Result<KdlNode> {
     Ok(node)
 }
 
-fn json_value_to_entry(json: &JsonValue) -> Result<KdlEntry> {
+fn convert_entry(json: &JsonValue) -> Result<KdlEntry> {
     let (actual_value, type_annotation) = if let Some(obj) = json.as_object() {
         let val = obj.get("value").unwrap_or(json);
         let ty = obj

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -184,10 +184,11 @@ fn convert_value(json: &JsonValue) -> Result<KdlValue> {
 }
 
 fn convert_type(json: &JsonValue) -> Result<Option<KdlIdentifier>> {
-    if !json.is_null() {
-        if let Some(type_str) = json.as_str() {
-            return Ok(Some(KdlIdentifier::from(type_str)));
-        }
+    match json {
+        JsonValue::String(ty) => Ok(Some(KdlIdentifier::from(ty.as_str()))),
+        JsonValue::Null => Ok(None),
+        _ => Err(ConversionError::InvalidStructure(
+            "type must be a string or null".to_string(),
+        )),
     }
-    Ok(None)
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -149,22 +149,16 @@ fn convert_node(json: &JsonValue) -> Result<KdlNode> {
 }
 
 fn convert_entry(json: &JsonValue) -> Result<KdlEntry> {
-    let (actual_value, type_annotation) = if let Some(obj) = json.as_object() {
-        let val = obj.get("value").unwrap_or(json);
-        let ty = obj
-            .get("type")
-            .and_then(|t| t.as_str())
-            .map(|s| s.to_string());
-        (val, ty)
-    } else {
-        (json, None)
-    };
+    let value = convert_value(json.get("value").unwrap_or(json))?;
 
-    let kdl_value = convert_value(actual_value)?;
+    let mut entry = KdlEntry::new(value);
 
-    let mut entry = KdlEntry::new(kdl_value);
-    if let Some(ty) = type_annotation {
-        entry.set_ty(ty);
+    if let Some(type_value) = json.get("type") {
+        if !type_value.is_null() {
+            if let Some(type_str) = type_value.as_str() {
+                entry.set_ty(type_str);
+            }
+        }
     }
 
     Ok(entry)

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -100,9 +100,10 @@ pub fn convert_document(json: &JsonValue) -> Result<KdlDocument> {
 }
 
 fn convert_node(json: &JsonValue) -> Result<KdlNode> {
-    let name = json.get("name").and_then(|n| n.as_str()).ok_or_else(|| {
-        ConversionError::InvalidStructure("name must be non-empty string".to_string())
-    })?;
+    let name = json
+        .get("name")
+        .and_then(|n| n.as_str())
+        .ok_or_else(|| ConversionError::InvalidStructure("name must be string".to_string()))?;
 
     let mut node = KdlNode::new(name);
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,4 +1,4 @@
-use kdl::{KdlDocument, KdlEntry, KdlNode, KdlValue, NodeKey};
+use kdl::{KdlDocument, KdlEntry, KdlIdentifier, KdlNode, KdlValue, NodeKey};
 use serde_json::Value as JsonValue;
 use std::{fmt, fs, path::Path};
 
@@ -137,11 +137,9 @@ fn convert_node(json: &JsonValue) -> Result<KdlNode> {
     }
 
     // Handle type annotation
-    if let Some(type_value) = json.get("type") {
-        if !type_value.is_null() {
-            if let Some(type_str) = type_value.as_str() {
-                node.set_ty(type_str);
-            }
+    if let Some(ty) = json.get("type") {
+        if let Some(ty) = convert_type(ty)? {
+            node.set_ty(ty);
         }
     }
 
@@ -153,11 +151,9 @@ fn convert_entry(json: &JsonValue) -> Result<KdlEntry> {
 
     let mut entry = KdlEntry::new(value);
 
-    if let Some(type_value) = json.get("type") {
-        if !type_value.is_null() {
-            if let Some(type_str) = type_value.as_str() {
-                entry.set_ty(type_str);
-            }
+    if let Some(ty) = json.get("type") {
+        if let Some(ty) = convert_type(ty)? {
+            entry.set_ty(ty);
         }
     }
 
@@ -184,4 +180,13 @@ fn convert_value(json: &JsonValue) -> Result<KdlValue> {
             "unsupported json value type for kdl conversion".to_string(),
         )),
     }
+}
+
+fn convert_type(json: &JsonValue) -> Result<Option<KdlIdentifier>> {
+    if !json.is_null() {
+        if let Some(type_str) = json.as_str() {
+            return Ok(Some(KdlIdentifier::from(type_str)));
+        }
+    }
+    Ok(None)
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -104,10 +104,15 @@ fn convert_node(json: &JsonValue) -> Result<KdlNode> {
         .as_object()
         .ok_or_else(|| ConversionError::InvalidStructure("node must be an object".to_string()))?;
 
-    let name = json
-        .get("name")
-        .and_then(|n| n.as_str())
-        .ok_or_else(|| ConversionError::InvalidStructure("name must be a string".to_string()))?;
+    let name = match json.get("name") {
+        Some(JsonValue::String(name)) => Ok(name.as_str()),
+        Some(_) => Err(ConversionError::InvalidStructure(
+            "name must be a string".to_string(),
+        )),
+        None => Err(ConversionError::InvalidStructure(
+            "node must have a name".to_string(),
+        )),
+    }?;
 
     let mut node = KdlNode::new(name);
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -85,13 +85,13 @@ pub fn convert_and_write_file_content(
 }
 
 pub fn convert_document(json: &JsonValue) -> Result<KdlDocument> {
-    let array = json.as_array().ok_or_else(|| {
+    let json = json.as_array().ok_or_else(|| {
         ConversionError::InvalidStructure("document root must be json array".to_string())
     })?;
 
     let mut document = KdlDocument::new();
 
-    for value in array {
+    for value in json {
         let node = convert_node(value)?;
         document.nodes_mut().push(node);
     }
@@ -108,11 +108,11 @@ fn convert_node(json: &JsonValue) -> Result<KdlNode> {
 
     // Handle arguments
     if let Some(arguments) = json.get("arguments") {
-        let args = arguments.as_array().ok_or_else(|| {
+        let arguments = arguments.as_array().ok_or_else(|| {
             ConversionError::InvalidStructure("arguments must be an array".to_string())
         })?;
 
-        for arg in args {
+        for arg in arguments {
             let entry = convert_entry(arg)?;
             node.push(entry);
         }
@@ -120,11 +120,11 @@ fn convert_node(json: &JsonValue) -> Result<KdlNode> {
 
     // Handle properties
     if let Some(properties) = json.get("properties") {
-        let props = properties.as_object().ok_or_else(|| {
+        let properties = properties.as_object().ok_or_else(|| {
             ConversionError::InvalidStructure("properties must be an object".to_string())
         })?;
 
-        for (key, prop_value) in props {
+        for (key, prop_value) in properties {
             let entry = convert_entry(prop_value)?;
             node.insert(NodeKey::from(key.clone()), entry);
         }
@@ -132,8 +132,8 @@ fn convert_node(json: &JsonValue) -> Result<KdlNode> {
 
     // Handle children
     if let Some(children) = json.get("children") {
-        let child_doc = convert_document(children)?;
-        node.set_children(child_doc);
+        let children = convert_document(children)?;
+        node.set_children(children);
     }
 
     // Handle type annotation

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -86,7 +86,7 @@ pub fn convert_and_write_file_content(
 
 pub fn convert_document(json: &JsonValue) -> Result<KdlDocument> {
     let json = json.as_array().ok_or_else(|| {
-        ConversionError::InvalidStructure("document root must be json array".to_string())
+        ConversionError::InvalidStructure("document root must be an array".to_string())
     })?;
 
     let mut document = KdlDocument::new();
@@ -103,7 +103,7 @@ fn convert_node(json: &JsonValue) -> Result<KdlNode> {
     let name = json
         .get("name")
         .and_then(|n| n.as_str())
-        .ok_or_else(|| ConversionError::InvalidStructure("name must be string".to_string()))?;
+        .ok_or_else(|| ConversionError::InvalidStructure("name must be a string".to_string()))?;
 
     let mut node = KdlNode::new(name);
 


### PR DESCRIPTION
I was going to make some changes to the formatting, but i got distracted and i ended up doing a lot of cleaning up and refactoring and other misc improvements.

- the command-line argument parsing is now more correct.
- some error messages are a bit more consistent or accurate.
- some obvious error cases that were ignored, are now actually errors.
- some allocation has been eliminated.
- a lot of internal names have been made more consistent.

there are a lot of individual changes; i tried to keep a tidy commit history when doing them. each commit is fairly small and individually valid; it's probably easier to review this commit-by-commit instead of looking at the final diff of all the commits and trying to review that.